### PR TITLE
Don't show the terminal if requested not to do

### DIFF
--- a/src/commandRunner.js
+++ b/src/commandRunner.js
@@ -53,7 +53,9 @@ class CommandRunner {
             this.createTerminal(options);
 
             // 显示终端
-            this.$$terminal.show(true);
+            if (typeof options === 'object' && options !== null && !options.hideFromUser) {
+                this.$$terminal.show(true);
+            }
 
             // 清空终端
             if (hasTerminal) {


### PR DESCRIPTION
The terminals [have an option](https://code.visualstudio.com/api/references/vscode-api#TerminalOptions) to prevent the terminal from being displayed, but it cannot work with this extension because it always show it after creating it. This diff makes sure to take the user option into account.
