### PR TITLE
Add selected files when the triggered from outside the explorer 

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -167,7 +167,7 @@ export default class Command {
         const terminal = createTerminal(terminalOptions);
 
         // 显示终端
-        if (autoFocus && terminal !== vscode.window.activeTerminal) {
+        if (autoFocus) {
             terminal.show();
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,10 +49,11 @@ export function activate(context: vscode.ExtensionContext): void {
             // 添加选中的文件
             if (files && files.length) {
                 files.forEach(argv => command.addFile(argv.fsPath));
-            } else { 
+            } else {
                 // Try to get the selected file from the explorer (Workaround)
                 await vscode.commands.executeCommand('copyFilePath');
-                command.addFile(await vscode.env.clipboard.readText());
+                const clipboardFiles = await vscode.env.clipboard.readText();
+                clipboardFiles.split(/\r?\n/).forEach(f => command.addFile(f));
             }
 
             // 执行命令

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // 注册【运行】命令
     context.subscriptions.push(
-        vscode.commands.registerCommand('command-runner.run', (opts: CommandOptions = {}, files?: vscode.Uri[]) => {
+        vscode.commands.registerCommand('command-runner.run', async (opts: CommandOptions = {}, files?: vscode.Uri[]) => {
             const command = new Command(context);
             const cmd = opts.command || opts.cmd || '';
 
@@ -49,6 +49,10 @@ export function activate(context: vscode.ExtensionContext): void {
             // 添加选中的文件
             if (files && files.length) {
                 files.forEach(argv => command.addFile(argv.fsPath));
+            } else { 
+                // Try to get the selected file from the explorer (Workaround)
+                await vscode.commands.executeCommand('copyFilePath');
+                command.addFile(await vscode.env.clipboard.readText())
             }
 
             // 执行命令

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,7 @@ export function activate(context: vscode.ExtensionContext): void {
             } else { 
                 // Try to get the selected file from the explorer (Workaround)
                 await vscode.commands.executeCommand('copyFilePath');
-                command.addFile(await vscode.env.clipboard.readText())
+                command.addFile(await vscode.env.clipboard.readText());
             }
 
             // 执行命令


### PR DESCRIPTION
1. Add selected files when the triggered from outside the explorer 
2. We don't need to check: terminal !== vscode.window.activeTerminal, coz it can be the "activeTerminal" but the whole panel is closed. So, why not just show the terminal!