### PR TITLE
Return the result of commands.

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -99,8 +99,7 @@ export default class Command {
                 case 'input':
                     return await this.$accessor.input(args) || args;
                 case 'command':
-                    args && vscode.commands.executeCommand(args);
-                    return '';
+                    return args && await vscode.commands.executeCommand<string>(args) as string;
                 default:
                     return this.$accessor.variable(variable as VariableScope);
             }


### PR DESCRIPTION
This is very useful in cases where the cmake output directory is needed.

`${command:cmake.getLaunchTargetDirectory}`

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>